### PR TITLE
versioning improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
+import org.gradle.util.GradleVersion
+
 buildscript {
     ext.shadowEnabled = JavaVersion.current().java8Compatible
     ext.sonarQubeEnabled = JavaVersion.current().java8Compatible
     ext.isJava12 = JavaVersion.current().getMajorVersion() == '12'
     ext.spotBugsEnabled = JavaVersion.current().java8Compatible && !isJava12
-    ext.consoleCoverageReporterEnabled = JavaVersion.current().java8Compatible && !JavaVersion.current().java11Compatible
+    ext.consoleCoverageReporterEnabled = JavaVersion.current().java8Compatible && GradleVersion.current() < GradleVersion.version("5.0")
     ext.checkStyleEnabled = !JavaVersion.current().java11Compatible
 
     repositories {

--- a/config/.gitlab-ci.yml
+++ b/config/.gitlab-ci.yml
@@ -38,7 +38,6 @@ Test Java 11 OpenJDK:
   stage: JDK Build and Test
   script:
     - unset SONAR_TOKEN
-    - ./gradlew wrapper --gradle-version=5.0-20181110000025+0000
     - ./gradlew --no-daemon check
 
 Test Java 12 OpenJDK:
@@ -49,7 +48,7 @@ Test Java 12 OpenJDK:
   allow_failure: true
   script:
     - unset SONAR_TOKEN
-    - ./gradlew wrapper --gradle-version=5.0-20181110000025+0000
+    - ./gradlew wrapper --gradle-version=5.0
     - ./gradlew --no-daemon check
 
 Publish Java 10 OpenJDK:


### PR DESCRIPTION
- make coverage reporting enabled based on Gradle version instead of Java (keep java 8+ req due to ssl issues in java 7 docker image)
- switch to stable release gradle 5
- run java 11 on gradle 4.10.2, seems to work now

updates based on #31 feedback